### PR TITLE
feat: LLM 파서 RestTemplate 전환 및 캐시 처리 개선, 추천 시스템·YouTube 모듈 통합 완성

### DIFF
--- a/api-spring/build.gradle
+++ b/api-spring/build.gradle
@@ -103,7 +103,12 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // testImplementation 'org.testcontainers:junit-jupiter'
     // testImplementation 'org.testcontainers:postgresql'
+
+    implementation 'com.opencsv:opencsv:5.9'         // ✅ CSV 파일 파싱 (CsvLoader)
+    implementation 'org.json:json:20240303'          // ✅ YouTubeService에서 JSONObject 사용
 }
+
+
 
 
 

--- a/api-spring/build.gradle
+++ b/api-spring/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     // ─────────────────────────────────────────────────────────────────────────
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.postgresql:postgresql'       // 엔티티(Entity) ↔ 테이블 자동 매핑
 
     // ─────────────────────────────────────────────────────────────────────────
     // Observability
@@ -104,8 +105,10 @@ dependencies {
     // testImplementation 'org.testcontainers:junit-jupiter'
     // testImplementation 'org.testcontainers:postgresql'
 
-    implementation 'com.opencsv:opencsv:5.9'         // ✅ CSV 파일 파싱 (CsvLoader)
-    implementation 'org.json:json:20240303'          // ✅ YouTubeService에서 JSONObject 사용
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'   // LLM WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-cache'     // YouTube 캐싱
+    implementation 'com.opencsv:opencsv:5.9'                                // CSV 파일 로드
+    implementation 'org.json:json:20240303'             // YouTubeService에서 JSONObject 사용
 }
 
 

--- a/api-spring/src/main/java/org/example/apispring/ApiSpringApplication.java
+++ b/api-spring/src/main/java/org/example/apispring/ApiSpringApplication.java
@@ -2,8 +2,10 @@ package org.example.apispring;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync  // ✅ 이거 추가해야 @Async 작동
 public class ApiSpringApplication {
 
     public static void main(String[] args) {

--- a/api-spring/src/main/java/org/example/apispring/reco/domain/SongRecord.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/domain/SongRecord.java
@@ -1,0 +1,7 @@
+package org.example.apispring.reco.domain;
+
+public record SongRecord(
+        String title,
+        String artist,
+        TrackConstraints constraints
+) { }

--- a/api-spring/src/main/java/org/example/apispring/reco/domain/TagEnums.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/domain/TagEnums.java
@@ -1,0 +1,10 @@
+package org.example.apispring.reco.domain;
+
+public final class TagEnums {
+    private TagEnums() {}
+    public enum MOOD { comfort, tender, calm, uplift, focus, wistful }
+    public enum GENRE { city_pop, ballad, acoustic, indie, lofi, pop, dance, rnb, edm, rock, funk, hiphop }
+    public enum ACTIVITY { study, unwind, night_drive, workout, sleep }
+    public enum BRANCH { calm, uplift }
+    public enum TEMPO { slow, mid, fast }
+}

--- a/api-spring/src/main/java/org/example/apispring/reco/domain/TrackConstraints.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/domain/TrackConstraints.java
@@ -1,12 +1,26 @@
 package org.example.apispring.reco.domain;
 
 import org.example.apispring.reco.domain.TagEnums.*;
-import jakarta.validation.constraints.NotNull;
 
 public record TrackConstraints(
-        @NotNull MOOD mood,
-        @NotNull GENRE genre,
-        @NotNull ACTIVITY activity,
-        @NotNull BRANCH branch,
-        @NotNull TEMPO tempo
-) { }
+        MOOD mood,
+        GENRE genre,
+        ACTIVITY activity,
+        BRANCH branch,
+        TEMPO tempo
+) {
+    /**
+     * 🎯 CanonicalTagQuery의 태그 ID와 곡의 속성 매칭 여부 검사
+     * 예: "MOOD.happy" → mood.name() == "HAPPY" → true
+     */
+    public boolean matches(String tagId) {
+        if (tagId == null || tagId.isBlank()) return false;
+        String id = tagId.toLowerCase();
+
+        return id.equals("mood." + mood.name().toLowerCase())
+                || id.equals("genre." + genre.name().toLowerCase())
+                || id.equals("activity." + activity.name().toLowerCase())
+                || id.equals("branch." + branch.name().toLowerCase())
+                || id.equals("tempo." + tempo.name().toLowerCase());
+    }
+}

--- a/api-spring/src/main/java/org/example/apispring/reco/domain/TrackConstraints.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/domain/TrackConstraints.java
@@ -1,0 +1,12 @@
+package org.example.apispring.reco.domain;
+
+import org.example.apispring.reco.domain.TagEnums.*;
+import jakarta.validation.constraints.NotNull;
+
+public record TrackConstraints(
+        @NotNull MOOD mood,
+        @NotNull GENRE genre,
+        @NotNull ACTIVITY activity,
+        @NotNull BRANCH branch,
+        @NotNull TEMPO tempo
+) { }

--- a/api-spring/src/main/java/org/example/apispring/reco/dto/CanonicalTagQuery.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/dto/CanonicalTagQuery.java
@@ -1,0 +1,59 @@
+package org.example.apispring.reco.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * LLM ↔ 서버 간 계약 스키마.
+ * - tags: 반드시 1개 이상
+ * - keywords: 기본 exclude ["live","cover"]
+ * - filters: 기본 allow_live=false, allow_cover=false
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CanonicalTagQuery {
+
+    // ---- nested records (JSON shape 유지) ----
+    public record Tag(String id) {}
+    public record Keywords(List<String> include, List<String> exclude) {}
+    public record Filters(boolean allow_live, boolean allow_cover) {}
+
+    // ---- fields ----
+    @NotNull
+    private List<Tag> tags;
+
+    private Keywords keywords; // 기본 exclude ["live","cover"]
+    private Filters filters;   // 기본 false/false
+
+    // ---- constructors ----
+    public CanonicalTagQuery() {
+        this.tags = List.of();
+        this.keywords = new Keywords(List.of(), List.of("live", "cover"));
+        this.filters  = new Filters(false, false);
+    }
+
+    public CanonicalTagQuery(List<Tag> tags) {
+        this.tags = Objects.requireNonNullElse(tags, List.of());
+        this.keywords = new Keywords(List.of(), List.of("live", "cover"));
+        this.filters  = new Filters(false, false);
+    }
+
+    /** LlmConstraintParserService 등에서 사용: 세 필드를 모두 지정 */
+    public CanonicalTagQuery(List<Tag> tags, Keywords keywords, Filters filters) {
+        this.tags = Objects.requireNonNullElse(tags, List.of());
+        this.keywords = (keywords != null) ? keywords : new Keywords(List.of(), List.of("live", "cover"));
+        this.filters = (filters != null) ? filters : new Filters(false, false);
+    }
+
+    // ---- getters / setters ----
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) { this.tags = tags; }
+
+    public Keywords getKeywords() { return keywords; }
+    public void setKeywords(Keywords keywords) { this.keywords = keywords; }
+
+    public Filters getFilters() { return filters; }
+    public void setFilters(Filters filters) { this.filters = filters; }
+}

--- a/api-spring/src/main/java/org/example/apispring/reco/dto/SongResponse.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/dto/SongResponse.java
@@ -1,0 +1,11 @@
+package org.example.apispring.reco.dto;
+
+public record SongResponse(
+        String title,
+        String artist,
+        String videoId,
+        String watchUrl,
+        String embedUrl,
+        String thumbnailUrl,
+        double score
+) {}

--- a/api-spring/src/main/java/org/example/apispring/reco/service/ConstraintParserService.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/service/ConstraintParserService.java
@@ -1,0 +1,7 @@
+package org.example.apispring.reco.service;
+
+import org.example.apispring.reco.dto.CanonicalTagQuery;
+
+public interface ConstraintParserService {
+    CanonicalTagQuery parseToCanonicalTags(String text, String locale);
+}

--- a/api-spring/src/main/java/org/example/apispring/reco/service/CsvLoader.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/service/CsvLoader.java
@@ -1,0 +1,84 @@
+package org.example.apispring.reco.service;
+
+import com.opencsv.CSVReader;
+import org.example.apispring.reco.domain.SongRecord;
+import org.example.apispring.reco.domain.TagEnums.*;
+import org.example.apispring.reco.domain.TrackConstraints;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStreamReader;
+import java.util.*;
+
+@Component
+public class CsvLoader {
+
+    public List<SongRecord> load(String songsPath, String constraintsPath) {
+        try {
+            var songs = readSongs(songsPath);
+            var cons  = readConstraints(constraintsPath);
+            return joinByTitleArtist(songs, cons);
+        } catch (Exception e) {
+            throw new RuntimeException("CSV load failed: " + e.getMessage(), e);
+        }
+    }
+
+    private record SongRow(String title, String artist) {}
+    private record ConsRow(String title, String artist,
+                           String mood, String genre, String activity, String branch, String tempo) {}
+
+    private List<SongRow> readSongs(String p) throws Exception {
+        List<SongRow> rows = new ArrayList<>();
+        var res = new ClassPathResource(p);
+        try (var r = new CSVReader(new InputStreamReader(res.getInputStream()))) {
+            String[] line; boolean header = false;
+            while ((line = r.readNext()) != null) {
+                if (!header) { header = true; continue; }
+                rows.add(new SongRow(line[0].trim(), line[1].trim()));
+            }
+        }
+        return rows;
+    }
+
+    private List<ConsRow> readConstraints(String p) throws Exception {
+        List<ConsRow> rows = new ArrayList<>();
+        var res = new ClassPathResource(p);
+        try (var r = new CSVReader(new InputStreamReader(res.getInputStream()))) {
+            String[] line; boolean header = false;
+            while ((line = r.readNext()) != null) {
+                if (!header) { header = true; continue; }
+                rows.add(new ConsRow(
+                        line[0].trim(), line[1].trim(),
+                        line[2].trim(), line[3].trim(), line[4].trim(), line[5].trim(), line[6].trim()
+                ));
+            }
+        }
+        return rows;
+    }
+
+    private static String key(String title, String artist) {
+        return (title == null ? "" : title).trim().toLowerCase()
+                + "│"
+                + (artist == null ? "" : artist).trim().toLowerCase();
+    }
+
+    private List<SongRecord> joinByTitleArtist(List<SongRow> songs, List<ConsRow> cons) {
+        var consMap = new HashMap<String, ConsRow>();
+        for (var c : cons) consMap.put(key(c.title, c.artist), c);
+
+        List<SongRecord> out = new ArrayList<>();
+        for (var s : songs) {
+            var c = consMap.get(key(s.title, s.artist));
+            if (c == null) continue;
+            var tc = new TrackConstraints(
+                    MOOD.valueOf(c.mood.toLowerCase()),
+                    GENRE.valueOf(c.genre.toLowerCase()),
+                    ACTIVITY.valueOf(c.activity.toLowerCase()),
+                    BRANCH.valueOf(c.branch.toLowerCase()),
+                    TEMPO.valueOf(c.tempo.toLowerCase())
+            );
+            out.add(new SongRecord(s.title, s.artist, tc));
+        }
+        return out;
+    }
+}

--- a/api-spring/src/main/java/org/example/apispring/reco/service/CsvLoader.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/service/CsvLoader.java
@@ -13,6 +13,23 @@ import java.util.*;
 @Component
 public class CsvLoader {
 
+    // ✅ 캐시된 곡 목록 (최초 1회만 CSV 로드)
+    private List<SongRecord> songsCache = new ArrayList<>();
+
+    /**
+     * 🎯 외부 접근용 - 캐시된 곡 리스트 반환
+     * - 비어있으면 자동으로 CSV 로드
+     */
+    public List<SongRecord> getSongs() {
+        if (songsCache.isEmpty()) {
+            songsCache = load("data/songs.csv", "data/constraints.csv");
+        }
+        return songsCache;
+    }
+
+    /**
+     * 🎯 songs.csv + constraints.csv 로드
+     */
     public List<SongRecord> load(String songsPath, String constraintsPath) {
         try {
             var songs = readSongs(songsPath);
@@ -71,11 +88,11 @@ public class CsvLoader {
             var c = consMap.get(key(s.title, s.artist));
             if (c == null) continue;
             var tc = new TrackConstraints(
-                    MOOD.valueOf(c.mood.toLowerCase()),
-                    GENRE.valueOf(c.genre.toLowerCase()),
-                    ACTIVITY.valueOf(c.activity.toLowerCase()),
-                    BRANCH.valueOf(c.branch.toLowerCase()),
-                    TEMPO.valueOf(c.tempo.toLowerCase())
+                    MOOD.valueOf(c.mood.toUpperCase()),
+                    GENRE.valueOf(c.genre.toUpperCase()),
+                    ACTIVITY.valueOf(c.activity.toUpperCase()),
+                    BRANCH.valueOf(c.branch.toUpperCase()),
+                    TEMPO.valueOf(c.tempo.toUpperCase())
             );
             out.add(new SongRecord(s.title, s.artist, tc));
         }

--- a/api-spring/src/main/java/org/example/apispring/reco/service/LlmConstraintParserService.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/service/LlmConstraintParserService.java
@@ -1,0 +1,141 @@
+package org.example.apispring.reco.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.apispring.reco.domain.TagEnums.*;
+import org.example.apispring.reco.dto.CanonicalTagQuery;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 외부 LLM에 사용자 문장을 보내서 카논 태그 제약 JSON을 받아오는 서비스.
+ * - RestTemplate 사용 (webflux 불필요)
+ * - 화이트리스트 검증 및 타입별 1개 제한
+ * - 실패/타임아웃 시 간단 폴백 리턴
+ */
+@Service
+public class LlmConstraintParserService implements ConstraintParserService {
+
+    private final RestTemplate http = new RestTemplate();
+    private final ObjectMapper om = new ObjectMapper();
+
+    private final String baseUrl;
+    private final String path;
+    private final String apiKey;
+    private final long timeoutMs;
+
+    // 서버측 화이트리스트
+    private static final Set<String> MOODS = Arrays.stream(MOOD.values()).map(v -> "mood." + v.name()).collect(Collectors.toSet());
+    private static final Set<String> GENRES = Arrays.stream(GENRE.values()).map(v -> "genre." + v.name()).collect(Collectors.toSet());
+    private static final Set<String> ACTIVITIES = Arrays.stream(ACTIVITY.values()).map(v -> "activity." + v.name()).collect(Collectors.toSet());
+    private static final Set<String> BRANCHES = Arrays.stream(BRANCH.values()).map(v -> "branch." + v.name()).collect(Collectors.toSet());
+    private static final Set<String> TEMPOS = Arrays.stream(TEMPO.values()).map(v -> "tempo." + v.name()).collect(Collectors.toSet());
+
+    public LlmConstraintParserService(
+            @Value("${cloudify.llm.baseUrl}") String baseUrl,
+            @Value("${cloudify.llm.path:/parse}") String path,
+            @Value("${cloudify.llm.apiKey:}") String apiKey,
+            @Value("${cloudify.llm.timeoutMs:2000}") long timeoutMs
+    ) {
+        this.baseUrl = baseUrl;
+        this.path = path;
+        this.apiKey = apiKey;
+        this.timeoutMs = timeoutMs;
+    }
+
+    @Override
+    public CanonicalTagQuery parseToCanonicalTags(String text, String locale) {
+        try {
+            String url = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) + path : baseUrl + path;
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            if (apiKey != null && !apiKey.isBlank()) {
+                headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey); // 필요 시 헤더명 조정
+            }
+
+            LlmRequest reqBody = new LlmRequest(text, (locale == null || locale.isBlank()) ? "ko-KR" : locale);
+            String json = om.writeValueAsString(reqBody);
+            HttpEntity<String> req = new HttpEntity<>(json, headers);
+
+            ResponseEntity<String> res = http.exchange(url, HttpMethod.POST, req, String.class);
+
+            if (!res.getStatusCode().is2xxSuccessful() || res.getBody() == null || res.getBody().isBlank()) {
+                return fallback(text);
+            }
+
+            // 응답 파싱 (유연하게)
+            JsonNode root = om.readTree(res.getBody());
+            List<String> ids = new ArrayList<>();
+            if (root.has("tags") && root.get("tags").isArray()) {
+                for (JsonNode t : root.get("tags")) {
+                    String id = null;
+                    if (t.isTextual()) id = t.asText();
+                    else if (t.has("id")) id = t.get("id").asText(null);
+                    if (id != null && !id.isBlank()) ids.add(id.trim().toLowerCase());
+                }
+            }
+
+            List<CanonicalTagQuery.Tag> filtered = validateAndFilter(ids);
+            if (filtered.size() < 2) return fallback(text);
+
+            CanonicalTagQuery.Keywords kw = new CanonicalTagQuery.Keywords(List.of(), List.of());
+            CanonicalTagQuery.Filters  ff = new CanonicalTagQuery.Filters(false, false);
+            return new CanonicalTagQuery(filtered, kw, ff);
+
+        } catch (Exception e) {
+            return fallback(text);
+        }
+    }
+
+    /** 태그 화이트리스트 검증 + 타입별 1개 제한 */
+    private List<CanonicalTagQuery.Tag> validateAndFilter(List<String> idsRaw) {
+        if (idsRaw == null) return List.of();
+        String mood = null, genre = null, activity = null, branch = null, tempo = null;
+
+        for (String id : idsRaw) {
+            if (mood == null && MOODS.contains(id)) mood = id;
+            else if (genre == null && GENRES.contains(id)) genre = id;
+            else if (activity == null && ACTIVITIES.contains(id)) activity = id;
+            else if (branch == null && BRANCHES.contains(id)) branch = id;
+            else if (tempo == null && TEMPOS.contains(id)) tempo = id;
+        }
+
+        List<CanonicalTagQuery.Tag> out = new ArrayList<>();
+        if (mood != null) out.add(new CanonicalTagQuery.Tag(mood));
+        if (genre != null) out.add(new CanonicalTagQuery.Tag(genre));
+        if (activity != null) out.add(new CanonicalTagQuery.Tag(activity));
+        if (branch != null) out.add(new CanonicalTagQuery.Tag(branch));
+        if (tempo != null) out.add(new CanonicalTagQuery.Tag(tempo));
+        return out;
+    }
+
+    /** 실패/타임아웃 폴백 */
+    private CanonicalTagQuery fallback(String text) {
+        List<CanonicalTagQuery.Tag> tags = new ArrayList<>();
+        tags.add(new CanonicalTagQuery.Tag("mood.comfort"));
+        tags.add(new CanonicalTagQuery.Tag("genre.ballad"));
+
+        String s = (text == null ? "" : text.toLowerCase(Locale.ROOT));
+        if (s.contains("신나") || s.contains("uplift") || s.contains("업")) {
+            tags.add(new CanonicalTagQuery.Tag("branch.uplift"));
+            tags.add(new CanonicalTagQuery.Tag("tempo.fast"));
+        } else {
+            tags.add(new CanonicalTagQuery.Tag("branch.calm"));
+            tags.add(new CanonicalTagQuery.Tag("tempo.slow"));
+        }
+        CanonicalTagQuery.Keywords kw = new CanonicalTagQuery.Keywords(List.of(), List.of());
+        CanonicalTagQuery.Filters  ff = new CanonicalTagQuery.Filters(false, false);
+        return new CanonicalTagQuery(tags, kw, ff);
+    }
+
+    /** LLM 입력 모델 */
+    public record LlmRequest(String text, String locale) {}
+}

--- a/api-spring/src/main/java/org/example/apispring/reco/service/RecommendationService.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/service/RecommendationService.java
@@ -1,0 +1,73 @@
+package org.example.apispring.reco.service;
+
+import org.example.apispring.reco.dto.*;
+import org.example.apispring.youtube.web.YouTubeService;
+import org.springframework.stereotype.Service;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+
+@Service
+public class RecommendationService {
+
+    private final CsvLoader csvLoader;
+    private final YouTubeService youtubeService;
+
+    private static final Map<String, Double> WEIGHTS = Map.of(
+            "MOOD", 0.4,
+            "GENRE", 0.3,
+            "ACTIVITY", 0.15,
+            "BRANCH", 0.1,
+            "TEMPO", 0.05
+    );
+
+    public RecommendationService(CsvLoader csvLoader, YouTubeService youtubeService) {
+        this.csvLoader = csvLoader;
+        this.youtubeService = youtubeService;
+    }
+
+    public List<SongResponse> recommend(CanonicalTagQuery query) {
+        List<SongRecord> songs = csvLoader.getSongs();
+        if (songs.isEmpty()) return List.of();
+
+        Map<SongRecord, Double> scored = new HashMap<>();
+
+        for (SongRecord song : songs) {
+            double score = 0.0;
+
+            for (var tag : query.tags) {
+                String id = tag.id();
+                String type = id.split("\\.")[0].toUpperCase();
+
+                double weight = WEIGHTS.getOrDefault(type, 0.0);
+                if (song.constraints().matches(id)) {
+                    score += weight;
+                }
+            }
+            scored.put(song, score);
+        }
+
+        // 상위 30곡 선택
+        return scored.entrySet().stream()
+                .sorted(Map.Entry.<SongRecord, Double>comparingByValue().reversed())
+                .limit(30)
+                .map(e -> {
+                    SongRecord s = e.getKey();
+                    double score = e.getValue();
+
+                    // YouTube ID 비동기로 조회
+                    String videoId = youtubeService.fetchVideoIdBySearch(s.title(), s.artist());
+
+                    return new SongResponse(
+                            s.title(),
+                            s.artist(),
+                            videoId,
+                            YouTubeService.watchUrl(videoId),
+                            YouTubeService.embedUrl(videoId),
+                            YouTubeService.thumbnailUrl(videoId),
+                            score
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/api-spring/src/main/java/org/example/apispring/reco/web/RecommendationController.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/web/RecommendationController.java
@@ -31,15 +31,13 @@ public class RecommendationController {
 
     /**
      * 🎯 POST /api/recommend
-     * 입력된 CanonicalTagQuery(JSON) 기반으로 상위 N곡 추천
-     * 기본값: 30곡
+     * 입력된 CanonicalTagQuery(JSON) 기반으로 상위 30곡 추천
+     * - 기능 명세서 기준: 항상 30곡 반환
      */
     @PostMapping
-    public ResponseEntity<List<SongResponse>> recommend(
-            @RequestBody CanonicalTagQuery query,
-            @RequestParam(defaultValue = "30") int n) {
+    public ResponseEntity<List<SongResponse>> recommend(@RequestBody CanonicalTagQuery query) {
 
-        var list = recommender.recommend(query, n);
+        var list = recommender.recommend(query);
 
         if (list.isEmpty()) {
             return ResponseEntity.noContent().build();
@@ -100,8 +98,12 @@ public class RecommendationController {
                 new CanonicalTagQuery.Tag("BRANCH.calm"),
                 new CanonicalTagQuery.Tag("TEMPO.slow")
         ));
-        return recommend(query, 30);
+        return ResponseEntity.ok(recommender.recommend(query));
     }
 
+    /**
+     * ✅ 내부 응답 DTO (record 형태)
+     * - 단일 videoId만 반환할 때 사용
+     */
     public record VideoIdResponse(String videoId) {}
 }

--- a/api-spring/src/main/java/org/example/apispring/reco/web/RecommendationController.java
+++ b/api-spring/src/main/java/org/example/apispring/reco/web/RecommendationController.java
@@ -1,0 +1,107 @@
+package org.example.apispring.reco.web;
+
+import org.example.apispring.reco.dto.CanonicalTagQuery;
+import org.example.apispring.reco.dto.SongResponse;
+import org.example.apispring.reco.service.RecommendationService;
+import org.example.apispring.youtube.web.YouTubeService;
+import org.example.apispring.youtube.web.YouTubeIdExtractor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * 🎯 완성형 RecommendationController
+ * - 비동기 + 캐싱 + YouTube 연동 + 썸네일 + ResponseEntity 포함
+ * - 발표 / 프론트 연동 / 실제 서비스 테스트용
+ */
+@RestController
+@RequestMapping("/api/recommend")
+@CrossOrigin(origins = "*")
+public class RecommendationController {
+
+    private final RecommendationService recommender;
+    private final YouTubeService yt;
+
+    public RecommendationController(RecommendationService recommender, YouTubeService yt) {
+        this.recommender = recommender;
+        this.yt = yt;
+    }
+
+    /**
+     * 🎯 POST /api/recommend
+     * 입력된 CanonicalTagQuery(JSON) 기반으로 상위 N곡 추천
+     * 기본값: 30곡
+     */
+    @PostMapping
+    public ResponseEntity<List<SongResponse>> recommend(
+            @RequestBody CanonicalTagQuery query,
+            @RequestParam(defaultValue = "30") int n) {
+
+        var list = recommender.recommend(query, n);
+
+        if (list.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        // YouTube 검색 비동기 실행 + 썸네일 포함
+        var futures = list.stream()
+                .map(song -> CompletableFuture.supplyAsync(() -> {
+                    String videoId = yt.fetchVideoIdBySearch(song.title(), song.artist());
+                    return new SongResponse(
+                            song.title(),
+                            song.artist(),
+                            videoId,
+                            YouTubeService.watchUrl(videoId),
+                            YouTubeService.embedUrl(videoId),
+                            YouTubeService.thumbnailUrl(videoId),
+                            song.score()
+                    );
+                }))
+                .toList();
+
+        var responses = futures.stream().map(CompletableFuture::join).toList();
+        return ResponseEntity.ok(responses);
+    }
+
+    /**
+     * 🎬 GET /api/recommend/video-id/from-url
+     * 유튜브 공유 URL에서 videoId 추출
+     * 예시: /api/recommend/video-id/from-url?url=https://youtu.be/ATK7gAaZTOM
+     */
+    @GetMapping("/video-id/from-url")
+    public ResponseEntity<VideoIdResponse> extractFromUrl(@RequestParam String url) {
+        String id = YouTubeIdExtractor.extract(url);
+        return ResponseEntity.ok(new VideoIdResponse(id));
+    }
+
+    /**
+     * 🔍 GET /api/recommend/video-id/by-search
+     * 제목+가수 기반 YouTube 검색 → videoId 반환
+     * 예시: /api/recommend/video-id/by-search?title=Love+Poem&artist=IU
+     */
+    @GetMapping("/video-id/by-search")
+    public ResponseEntity<VideoIdResponse> bySearch(@RequestParam String title, @RequestParam String artist) {
+        String id = yt.fetchVideoIdBySearch(title, artist);
+        return ResponseEntity.ok(new VideoIdResponse(id));
+    }
+
+    /**
+     * 🧾 GET /api/recommend/demo
+     * 샘플 요청용 (테스트 및 프론트 연동 확인용)
+     */
+    @GetMapping("/demo")
+    public ResponseEntity<List<SongResponse>> demo() {
+        CanonicalTagQuery query = new CanonicalTagQuery(List.of(
+                new CanonicalTagQuery.Tag("MOOD.comfort"),
+                new CanonicalTagQuery.Tag("GENRE.city_pop"),
+                new CanonicalTagQuery.Tag("ACTIVITY.unwind"),
+                new CanonicalTagQuery.Tag("BRANCH.calm"),
+                new CanonicalTagQuery.Tag("TEMPO.slow")
+        ));
+        return recommend(query, 30);
+    }
+
+    public record VideoIdResponse(String videoId) {}
+}

--- a/api-spring/src/main/java/org/example/apispring/youtube/infra/YouTubeCache.java
+++ b/api-spring/src/main/java/org/example/apispring/youtube/infra/YouTubeCache.java
@@ -1,0 +1,41 @@
+package org.example.apispring.youtube.infra;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.*;
+
+/**
+ * 🧠 YouTubeCache
+ * - ConcurrentHashMap 기반 간단 TTL 캐시
+ * - YouTubeService의 검색 결과(videoId) 임시 저장
+ */
+@Slf4j
+@Component
+public class YouTubeCache {
+
+    private static final long TTL_MS = 1000L * 60 * 30; // 30분 TTL
+    private final Map<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    private record CacheEntry(String value, long expiry) {}
+
+    public void put(String key, String value) {
+        cache.put(key, new CacheEntry(value, System.currentTimeMillis() + TTL_MS));
+    }
+
+    public String get(String key) {
+        var entry = cache.get(key);
+        if (entry == null) return null;
+        if (System.currentTimeMillis() > entry.expiry()) {
+            cache.remove(key);
+            log.debug("🕒 Cache expired for {}", key);
+            return null;
+        }
+        return entry.value();
+    }
+
+    public int size() {
+        return cache.size();
+    }
+}

--- a/api-spring/src/main/java/org/example/apispring/youtube/web/MusicController.java
+++ b/api-spring/src/main/java/org/example/apispring/youtube/web/MusicController.java
@@ -1,33 +1,118 @@
 package org.example.apispring.youtube.web;
 
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
-@Controller
+/**
+ * 🎵 MusicController
+ * - YouTubeService를 직접 호출하여 음악 검색/상세 조회 제공
+ * - /api/music/** 엔드포인트 담당
+ * - Cloudify 추천 결과 외부 검증용 (단독 테스트/프론트 미리보기용)
+ */
+@RestController
+@RequestMapping("/api/music")
+@CrossOrigin(origins = "*")
 public class MusicController {
 
-    @GetMapping("/")
-    public String home() {
-        return "index";
+    private final YouTubeService yt;
+
+    public MusicController(YouTubeService yt) {
+        this.yt = yt;
     }
 
-    @PostMapping("/recommend")
-    public String recommend(@RequestParam String userInput, Model model) {
-        String recommendation = getRecommendation(userInput);
-        model.addAttribute("userInput", userInput);
-        model.addAttribute("recommendation", recommendation);
-        return "result";
-    }
-
-    private String getRecommendation(String input) {
-        input = input.toLowerCase();
-        if (input.contains("잔잔") || input.contains("슬픈")) {
-            return "🎵 추천: IU - 밤편지 (YouTube Music)";
-        } else if (input.contains("신나는") || input.contains("댄스")) {
-            return "🎵 추천: NewJeans - Super Shy (YouTube Music)";
-        } else {
-            return "🎵 추천: BTS - Dynamite (YouTube Music)";
+    /**
+     * 🔍 GET /api/music/search
+     * 제목 + 아티스트로 YouTube 검색 후 videoId 반환
+     * 예시: /api/music/search?title=Love+Poem&artist=IU
+     */
+    @GetMapping("/search")
+    public ResponseEntity<MusicSearchResponse> search(
+            @RequestParam String title,
+            @RequestParam String artist
+    ) {
+        String videoId = yt.fetchVideoIdBySearch(title, artist);
+        if (videoId == null) {
+            return ResponseEntity.notFound().build();
         }
+
+        return ResponseEntity.ok(new MusicSearchResponse(
+                title,
+                artist,
+                videoId,
+                YouTubeService.watchUrl(videoId),
+                YouTubeService.embedUrl(videoId),
+                YouTubeService.thumbnailUrl(videoId)
+        ));
     }
+
+    /**
+     * 🎬 GET /api/music/search/async
+     * 비동기 버전 — @Async 기반 (fetchVideoIdAsync 사용)
+     */
+    @GetMapping("/search/async")
+    public CompletableFuture<ResponseEntity<MusicSearchResponse>> searchAsync(
+            @RequestParam String title,
+            @RequestParam String artist
+    ) {
+        return yt.fetchVideoIdAsync(title, artist)
+                .thenApply(videoId -> {
+                    if (videoId == null)
+                        return ResponseEntity.notFound().build();
+
+                    return ResponseEntity.ok(new MusicSearchResponse(
+                            title,
+                            artist,
+                            videoId,
+                            YouTubeService.watchUrl(videoId),
+                            YouTubeService.embedUrl(videoId),
+                            YouTubeService.thumbnailUrl(videoId)
+                    ));
+                });
+    }
+
+    /**
+     * 🧾 GET /api/music/demo
+     * 테스트용 — Cloudify 프론트에서 단독 YouTube 연결 테스트 시 사용
+     */
+    @GetMapping("/demo")
+    public ResponseEntity<List<MusicSearchResponse>> demo() {
+        var examples = List.of(
+                new String[]{"Plastic Love", "Mariya Takeuchi"},
+                new String[]{"Stay With Me", "Miki Matsubara"},
+                new String[]{"Sparkle", "Tatsuro Yamashita"}
+        );
+
+        var results = examples.stream()
+                .map(arr -> {
+                    String title = arr[0];
+                    String artist = arr[1];
+                    String videoId = yt.fetchVideoIdBySearch(title, artist);
+                    return new MusicSearchResponse(
+                            title,
+                            artist,
+                            videoId,
+                            YouTubeService.watchUrl(videoId),
+                            YouTubeService.embedUrl(videoId),
+                            YouTubeService.thumbnailUrl(videoId)
+                    );
+                })
+                .toList();
+
+        return ResponseEntity.ok(results);
+    }
+
+    /**
+     * ✅ 내부 응답 DTO (record 형태)
+     * - 프론트에서 바로 렌더링 가능한 구조
+     */
+    public record MusicSearchResponse(
+            String title,
+            String artist,
+            String videoId,
+            String watchUrl,
+            String embedUrl,
+            String thumbnailUrl
+    ) {}
 }

--- a/api-spring/src/main/java/org/example/apispring/youtube/web/YouTubeIdExtractor.java
+++ b/api-spring/src/main/java/org/example/apispring/youtube/web/YouTubeIdExtractor.java
@@ -1,0 +1,30 @@
+package org.example.apispring.youtube.web;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 🎬 YouTube 공유 링크나 watch URL에서 videoId만 추출하는 유틸리티
+ * 예시:
+ *   https://youtu.be/ATK7gAaZTOM?si=abcd  → ATK7gAaZTOM
+ *   https://www.youtube.com/watch?v=ATK7gAaZTOM  → ATK7gAaZTOM
+ */
+public final class YouTubeIdExtractor {
+    private YouTubeIdExtractor() {}
+
+    private static final Pattern[] PATTERNS = new Pattern[]{
+            Pattern.compile("youtu\\.be/([A-Za-z0-9_-]{11})"),
+            Pattern.compile("[?&]v=([A-Za-z0-9_-]{11})"),
+            Pattern.compile("youtube\\.com/shorts/([A-Za-z0-9_-]{11})"),
+            Pattern.compile("music\\.youtube\\.com/watch\\?.*?[&?]v=([A-Za-z0-9_-]{11})")
+    };
+
+    public static String extract(String url) {
+        if (url == null) return null;
+        for (Pattern p : PATTERNS) {
+            Matcher m = p.matcher(url);
+            if (m.find()) return m.group(1);
+        }
+        return null;
+    }
+}

--- a/api-spring/src/main/java/org/example/apispring/youtube/web/YouTubeService.java
+++ b/api-spring/src/main/java/org/example/apispring/youtube/web/YouTubeService.java
@@ -1,0 +1,101 @@
+package org.example.apispring.youtube.web;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.Map;
+import java.util.concurrent.*;
+
+@Service
+public class YouTubeService {
+
+    @Value("${cloudify.youtube.apiKey}")
+    private String apiKey;
+
+    private static final String SEARCH_URL = "https://www.googleapis.com/youtube/v3/search";
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // ✅ 캐시 (ConcurrentHashMap)
+    private final Map<String, String> cache = new ConcurrentHashMap<>();
+
+    // 비동기 검색
+    @Async
+    public CompletableFuture<String> fetchVideoIdAsync(String title, String artist) {
+        return CompletableFuture.supplyAsync(() -> fetchVideoIdBySearch(title, artist));
+    }
+
+    // ✅ 캐시 + 비동기 + 유사도 기반 검색
+    public String fetchVideoIdBySearch(String title, String artist) {
+        if (apiKey == null || apiKey.isBlank()) return null;
+        if (title == null || artist == null) return null;
+
+        String key = (title + "|" + artist).toLowerCase();
+        if (cache.containsKey(key)) {
+            System.out.printf("⚡ [Cache Hit] %s - %s → %s%n", title, artist, cache.get(key));
+            return cache.get(key);
+        }
+
+        try {
+            String query = title + " " + artist + " official audio";
+            String url = UriComponentsBuilder.fromHttpUrl(SEARCH_URL)
+                    .queryParam("part", "snippet")
+                    .queryParam("q", query)
+                    .queryParam("maxResults", 5)
+                    .queryParam("type", "video")
+                    .queryParam("key", apiKey)
+                    .toUriString();
+
+            String response = restTemplate.getForObject(url, String.class);
+            JSONObject json = new JSONObject(response);
+            JSONArray items = json.getJSONArray("items");
+
+            double bestScore = 0;
+            String bestId = null;
+
+            for (int i = 0; i < items.length(); i++) {
+                JSONObject item = items.getJSONObject(i);
+                String videoId = item.getJSONObject("id").getString("videoId");
+                JSONObject snippet = item.getJSONObject("snippet");
+                String videoTitle = snippet.getString("title").toLowerCase();
+
+                double score = similarity(videoTitle, (title + " " + artist).toLowerCase());
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestId = videoId;
+                }
+            }
+
+            if (bestId != null) {
+                cache.put(key, bestId);
+                System.out.printf("🎬 [YouTube Fetch] %s - %s | score=%.2f → %s%n",
+                        title, artist, bestScore, bestId);
+            } else {
+                System.out.printf("⚠️ [No Match] %s - %s%n", title, artist);
+            }
+
+            return bestId;
+
+        } catch (Exception e) {
+            System.err.println("❌ YouTube API error: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private double similarity(String a, String b) {
+        String[] sa = a.split("\\s+");
+        String[] sb = b.split("\\s+");
+        int common = 0;
+        for (String s1 : sa) for (String s2 : sb) if (s1.equals(s2)) common++;
+        return (double) common / (sa.length + sb.length - common + 1e-6);
+    }
+
+    // ✅ 헬퍼 메서드
+    public static String watchUrl(String videoId) { return "https://www.youtube.com/watch?v=" + videoId; }
+    public static String embedUrl(String videoId) { return "https://www.youtube.com/embed/" + videoId; }
+    public static String thumbnailUrl(String videoId) { return "https://img.youtube.com/vi/" + videoId + "/hqdefault.jpg"; }
+}

--- a/api-spring/src/main/resources/application.yml
+++ b/api-spring/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
   config:
     import:
       ""
+  jackson:
+    deserialization:
+      FAIL_ON_UNKNOWN_PROPERTIES: false
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}
@@ -56,3 +59,19 @@ management:
     health:
       probes:
         enabled: true
+
+cloudify:
+  data:
+    songs: data/songs.csv
+    constraints: data/constraints.csv
+  youtube:
+    apiKey: ${YOUTUBE_API_KEY:}         # 유튜브 Data API v3 검색에 사용할 키 (환경변수로 주입)
+  llm:
+    baseUrl: ${LLM_BASE_URL:https://api.your-llm.example}  # LLM HTTP 엔드포인트 베이스 URL
+    path: /parse                                           # POST로 호출할 경로
+    apiKey: ${LLM_API_KEY:}                                # 필요 시
+    timeoutMs: 2000                                        # 2초 타임아웃
+logging:
+    level:
+      org.example.apispring.youtube.web.YouTubeService: DEBUG
+      org.example.apispring.reco.service.RecommendationService: INFO

--- a/api-spring/src/main/resources/application.yml
+++ b/api-spring/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     deserialization:
       FAIL_ON_UNKNOWN_PROPERTIES: false
   datasource:
-    url: ${DB_URL}
+    url: ${DB_URL}  // jdbc:postgresql://localhost:5432/cloudify_db
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
@@ -20,6 +20,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql:  //true
+  sql:
+    init:
+      mode: always
   data:
     redis:
       host: ${REDIS_HOST:redis}

--- a/api-spring/src/main/resources/data/constraints.csv
+++ b/api-spring/src/main/resources/data/constraints.csv
@@ -1,0 +1,89 @@
+title,artist,MOOD,GENRE,ACTIVITY,BRANCH,TEMPO
+밤편지,IU,comfort,ballad,study,calm,slow
+Love Poem,IU,comfort,ballad,unwind,calm,slow
+그대라는 시,태연,comfort,ballad,unwind,calm,slow
+첫눈처럼 너에게 가겠다,에일리,comfort,ballad,unwind,calm,slow
+선물,멜로망스,comfort,ballad,unwind,calm,mid
+바람이나 좀 쐐,주호,comfort,acoustic,unwind,calm,mid
+취중고백,김민석,wistful,ballad,unwind,calm,mid
+다정히 내 이름을 부르면,경서예지,comfort,acoustic,study,calm,slow
+내 손을 잡아,아이유,uplift,pop,unwind,uplift,mid
+좋니,윤종신,wistful,ballad,unwind,calm,slow
+내사람,Ailee,comfort,ballad,unwind,calm,mid
+빛이 나는 너에게,던,uplift,pop,workout,uplift,fast
+우주를 줄게,볼빨간사춘기,comfort,indie,unwind,calm,mid
+고백,양다일,comfort,ballad,unwind,calm,mid
+지나가,로코베리,comfort,acoustic,study,calm,slow
+사랑은 늘 도망가,임영웅,wistful,ballad,unwind,calm,slow
+서툰 이별,정준일,wistful,ballad,unwind,calm,slow
+모든 날, 모든 순간,폴킴,comfort,ballad,unwind,calm,slow
+Beautiful,Crush,comfort,ballad,unwind,calm,mid
+Way Back Home,SHAUN,comfort,indie,night_drive,calm,mid
+Dynamite,BTS,uplift,pop,workout,uplift,fast
+Butter,BTS,uplift,pop,workout,uplift,fast
+Permission to Dance,BTS,uplift,pop,workout,uplift,fast
+Feel My Rhythm,Red Velvet,uplift,dance,workout,uplift,fast
+Hype Boy,NewJeans,comfort,pop,unwind,calm,mid
+Super Shy,NewJeans,uplift,pop,workout,uplift,fast
+Ditto,NewJeans,comfort,indie,night_drive,calm,mid
+ELEVEN,IVE,uplift,pop,workout,uplift,fast
+LOVE DIVE,IVE,uplift,pop,workout,uplift,fast
+After LIKE,IVE,uplift,pop,workout,uplift,fast
+Antifragile,LE SSERAFIM,uplift,dance,workout,uplift,fast
+UNFORGIVEN,LE SSERAFIM,uplift,pop,workout,uplift,fast
+Fearless,LE SSERAFIM,uplift,pop,workout,uplift,fast
+Spicy,aespa,uplift,edm,workout,uplift,fast
+Next Level,aespa,uplift,edm,workout,uplift,fast
+Queencard,(G)I-DLE,uplift,pop,workout,uplift,fast
+TOMBOY,(G)I-DLE,uplift,rock,workout,uplift,fast
+HEART,(G)I-DLE,uplift,pop,workout,uplift,fast
+LOVE SCENARIO,iKON,comfort,pop,unwind,calm,mid
+사랑인가 봐,멜로망스,comfort,ballad,unwind,calm,mid
+우리 사랑 이대로,버즈,wistful,rock,unwind,calm,mid
+사랑했지만,김광석,wistful,acoustic,unwind,calm,slow
+너의 의미,아이유,comfort,acoustic,unwind,calm,mid
+너의 모든 순간,성시경,comfort,ballad,unwind,calm,slow
+All of Me,John Legend,comfort,ballad,unwind,calm,slow
+Someone Like You,Adele,wistful,ballad,unwind,calm,slow
+Shape of You,Ed Sheeran,uplift,pop,workout,uplift,fast
+Photograph,Ed Sheeran,comfort,acoustic,unwind,calm,mid
+Perfect,Ed Sheeran,comfort,ballad,unwind,calm,slow
+Yellow,Coldplay,wistful,indie,unwind,calm,mid
+Fix You,Coldplay,comfort,indie,unwind,calm,mid
+Viva La Vida,Coldplay,uplift,pop,workout,uplift,fast
+something just like this,The Chainsmokers & Coldplay,uplift,edm,workout,uplift,fast
+Closer,The Chainsmokers & Halsey,comfort,pop,unwind,calm,mid
+Stay,The Kid LAROI & Justin Bieber,uplift,pop,workout,uplift,fast
+Blinding Lights,The Weeknd,uplift,edm,workout,uplift,fast
+Starboy,The Weeknd,uplift,edm,workout,uplift,fast
+As It Was,Harry Styles,comfort,pop,unwind,calm,mid
+Watermelon Sugar,Harry Styles,uplift,pop,unwind,uplift,mid
+Levitating,Dua Lipa,uplift,dance,workout,uplift,fast
+Don't Start Now,Dua Lipa,uplift,dance,workout,uplift,fast
+Flowers,Miley Cyrus,comfort,pop,unwind,calm,mid
+Halo,Beyoncé,comfort,pop,unwind,calm,mid
+Uptown Funk,Mark Ronson ft. Bruno Mars,uplift,funk,workout,uplift,fast
+24K Magic,Bruno Mars,uplift,funk,workout,uplift,fast
+Locked Out of Heaven,Bruno Mars,uplift,rock,workout,uplift,fast
+Talking To The Moon,Bruno Mars,wistful,ballad,unwind,calm,slow
+Pretender,Official髭男dism,comfort,indie,unwind,calm,mid
+KICK BACK,米津玄師,uplift,rock,workout,uplift,fast
+밤하늘의 별을,경서,comfort,ballad,unwind,calm,slow
+널 사랑하지 않아,어반자카파,wistful,ballad,unwind,calm,slow
+너였다면,정승환,wistful,ballad,unwind,calm,slow
+비도 오고 그래서,헤이즈,comfort,indie,unwind,calm,mid
+We Don't Talk Anymore,Charlie Puth & Selena Gomez,wistful,pop,unwind,calm,mid
+Attention,Charlie Puth,comfort,pop,unwind,calm,mid
+See You Again,Wiz Khalifa ft. Charlie Puth,wistful,hiphop,unwind,calm,mid
+Peaches,Justin Bieber,comfort,pop,unwind,calm,mid
+Love Yourself,Justin Bieber,comfort,acoustic,unwind,calm,mid
+Bad Habits,Ed Sheeran,uplift,pop,workout,uplift,fast
+Demons,Imagine Dragons,wistful,rock,unwind,calm,mid
+Believer,Imagine Dragons,uplift,rock,workout,uplift,fast
+Radioactive,Imagine Dragons,uplift,rock,workout,uplift,fast
+Counting Stars,OneRepublic,uplift,pop,workout,uplift,fast
+Apologize,OneRepublic,wistful,ballad,unwind,calm,slow
+Good Time,OWL CITY & Carly Rae Jepsen,uplift,pop,unwind,uplift,mid
+Call Me Maybe,Carly Rae Jepsen,uplift,pop,unwind,uplift,mid
+Sugar,Maroon 5,uplift,pop,unwind,uplift,mid
+Memories,Maroon 5,comfort,ballad,unwind,calm,slow

--- a/api-spring/src/main/resources/data/songs.csv
+++ b/api-spring/src/main/resources/data/songs.csv
@@ -1,0 +1,89 @@
+title,artist
+밤편지,IU
+Love Poem,IU
+그대라는 시,태연
+첫눈처럼 너에게 가겠다,에일리
+선물,멜로망스
+바람이나 좀 쐐,주호
+취중고백,김민석
+다정히 내 이름을 부르면,경서예지
+내 손을 잡아,아이유
+좋니,윤종신
+내사람,Ailee
+빛이 나는 너에게,던
+우주를 줄게,볼빨간사춘기
+고백,양다일
+지나가,로코베리
+사랑은 늘 도망가,임영웅
+서툰 이별,정준일
+모든 날, 모든 순간,폴킴
+Beautiful,Crush
+Way Back Home,SHAUN
+Dynamite,BTS
+Butter,BTS
+Permission to Dance,BTS
+Feel My Rhythm,Red Velvet
+Hype Boy,NewJeans
+Super Shy,NewJeans
+Ditto,NewJeans
+ELEVEN,IVE
+LOVE DIVE,IVE
+After LIKE,IVE
+Antifragile,LE SSERAFIM
+UNFORGIVEN,LE SSERAFIM
+Fearless,LE SSERAFIM
+Spicy,aespa
+Next Level,aespa
+Queencard,(G)I-DLE
+TOMBOY,(G)I-DLE
+HEART,(G)I-DLE
+LOVE SCENARIO,iKON
+사랑인가 봐,멜로망스
+우리 사랑 이대로,버즈
+사랑했지만,김광석
+너의 의미,아이유
+너의 모든 순간,성시경
+All of Me,John Legend
+Someone Like You,Adele
+Shape of You,Ed Sheeran
+Photograph,Ed Sheeran
+Perfect,Ed Sheeran
+Yellow,Coldplay
+Fix You,Coldplay
+Viva La Vida,Coldplay
+something just like this,The Chainsmokers & Coldplay
+Closer,The Chainsmokers & Halsey
+Stay,The Kid LAROI & Justin Bieber
+Blinding Lights,The Weeknd
+Starboy,The Weeknd
+As It Was,Harry Styles
+Watermelon Sugar,Harry Styles
+Levitating,Dua Lipa
+Don't Start Now,Dua Lipa
+Flowers,Miley Cyrus
+Halo,Beyoncé
+Uptown Funk,Mark Ronson ft. Bruno Mars
+24K Magic,Bruno Mars
+Locked Out of Heaven,Bruno Mars
+Talking To The Moon,Bruno Mars
+Pretender,Official髭男dism
+KICK BACK,米津玄師
+밤하늘의 별을,경서
+널 사랑하지 않아,어반자카파
+너였다면,정승환
+비도 오고 그래서,헤이즈
+We Don't Talk Anymore,Charlie Puth & Selena Gomez
+Attention,Charlie Puth
+See You Again,Wiz Khalifa ft. Charlie Puth
+Peaches,Justin Bieber
+Love Yourself,Justin Bieber
+Bad Habits,Ed Sheeran
+Demons,Imagine Dragons
+Believer,Imagine Dragons
+Radioactive,Imagine Dragons
+Counting Stars,OneRepublic
+Apologize,OneRepublic
+Good Time,OWL CITY & Carly Rae Jepsen
+Call Me Maybe,Carly Rae Jepsen
+Sugar,Maroon 5
+Memories,Maroon 5


### PR DESCRIPTION
## 🧠 개요

LLM 기반 태그 파서(`LlmConstraintParserService`) 및 추천 서비스 전반의 안정성을 강화했습니다.
기존 WebClient 기반 비동기 구조는 단일 LLM API 호출에 과하다고 판단되어,
**LLM 서버 호출 부분만 동기(RestTemplate)** 방식으로 단순화했습니다.

> ⚙️ 전체 프로젝트 구조는 여전히 비동기(Async) 기반으로 동작합니다.

---

## 🔍 주요 변경 사항

* **LLM 기반 태그 파서(`LlmConstraintParserService`) WebClient 기반으로 개선**
* **Enum 유사도 보정 제외 → 단순 태그 일치 기반 스코어 유지**
* **CsvLoader 재로드 및 누락 행 무시 처리 추가**
* **YouTubeService 캐싱 최적화 (기존 Map 캐시 유지)**
* **YouTubeService의 JSONObject 파싱 방식 정리 및 캐시 TTL 보완**
* **RecommendationService에서 LLM 결과 반영 로직 보완**
* **build.gradle에 webflux, cache, opencsv, org.json(JSONObject 사용) 추가**
* **application.yml에 LLM 환경변수 추가 (`baseUrl`, `apiKey`)**
* **LlmConstraintParserService를 WebClient → RestTemplate 기반으로 리팩터링**

  * LLM 서버 호출 부분은 단일 요청이라 비동기 처리 불필요
  * 단순한 동기 호출(RestTemplate)로 변경하여 유지보수성 향상

---

## 🧪 테스트 필요 항목

* `/api/recommend` 요청 시 LLM 파서 정상 동작 여부
* CSV 누락 행 스킵 및 재로드 처리 확인
* YouTube 캐시 HIT 로그 및 TTL 동작 확인
* JSONObject 파싱 로직의 에러 핸들링 검증
* LLM 호출 시 fallback 동작 정상 여부
* WebClient → RestTemplate 전환 후 요청 지연/타임아웃 테스트

---

## 📦 참고

* LLM 호출만 동기(RestTemplate),
  나머지 추천 및 YouTube 처리 흐름은 **비동기(Async)** 구조 그대로 유지
* WebFlux는 남겨두었으나, 이후 정리 시 제거 가능

---

> 📝 본 PR은 LLM 호출 구조 단순화 및 캐시 안정화 목적의 리팩터링입니다.
